### PR TITLE
Add --domain-parallelism flag to fetch

### DIFF
--- a/minet/cli/commands.py
+++ b/minet/cli/commands.py
@@ -774,7 +774,7 @@ MINET_COMMANDS = {
                 'help': 'The http method to use. Will default to GET.',
                 'dest': 'method',
                 'default': 'GET'
-            },
+            }
         ]
     },
 

--- a/minet/cli/commands.py
+++ b/minet/cli/commands.py
@@ -706,6 +706,12 @@ MINET_COMMANDS = {
                 'default': DEFAULT_CONTENT_FOLDER
             },
             {
+                'flag': '--domain-parallelism',
+                'help': 'Max number of urls per domain to hit at the same time. Defaults to 1',
+                'type': int,
+                'default': 1
+            },
+            {
                 'flags': ['-f', '--filename'],
                 'help': 'Name of the column used to build retrieved file names. Defaults to an uuid v4 with correct extension.'
             },
@@ -768,12 +774,6 @@ MINET_COMMANDS = {
                 'help': 'The http method to use. Will default to GET.',
                 'dest': 'method',
                 'default': 'GET'
-            },
-            {
-                'flag': '--domain-parallelism',
-                'help': 'Max number of urls per domain to hit at the same time. Defaults to 1',
-                'type': int,
-                'default': 1
             },
         ]
     },

--- a/minet/cli/commands.py
+++ b/minet/cli/commands.py
@@ -768,7 +768,13 @@ MINET_COMMANDS = {
                 'help': 'The http method to use. Will default to GET.',
                 'dest': 'method',
                 'default': 'GET'
-            }
+            },
+            {
+                'flag': '--domain-parallelism',
+                'help': 'Max number of urls per domain to hit at the same time. Defaults to 1',
+                'type': int,
+                'default': 1
+            },
         ]
     },
 

--- a/minet/cli/fetch.py
+++ b/minet/cli/fetch.py
@@ -204,7 +204,7 @@ def fetch_action(namespace):
         request_args=request_args,
         threads=namespace.threads,
         throttle=namespace.throttle,
-        domain_parallelism=namespace.domain_parallelism,
+        domain_parallelism=namespace.domain_parallelism
     )
 
     for result in multithreaded_iterator:

--- a/minet/cli/fetch.py
+++ b/minet/cli/fetch.py
@@ -203,7 +203,8 @@ def fetch_action(namespace):
         key=url_key,
         request_args=request_args,
         threads=namespace.threads,
-        throttle=namespace.throttle
+        throttle=namespace.throttle,
+        domain_parallelism=namespace.domain_parallelism,
     )
 
     for result in multithreaded_iterator:


### PR DESCRIPTION
When using `minet fetch`, I was looking to use this option so I added to the CLI options