### PR TITLE
Deprecation notice about urllib3[secure]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ tqdm==4.60.0
 trafilatura==1.2.0
 twitwi==0.14.0
 ural==0.32.0
-urllib3[secure]==1.26.9
+urllib3==1.26.9

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "trafilatura>=1.2.0,<1.3",
         "twitwi>=0.14.0,<0.15",
         "ural>=0.32.0,<0.33",
-        "urllib3[secure]>=1.26.9,<2",
+        "urllib3>=1.26.9,<2",
     ],
     entry_points={"console_scripts": ["minet=minet.cli.__main__:main"]},
     zip_safe=True,


### PR DESCRIPTION
### Description

pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680
removed urllib3[secure] from setup.py and requirement.txtfile.
updated both files with urllib3