### PR TITLE
fix for GH API rate limit on install #451

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,16 +57,16 @@ fail_install() {
 }
 
 verify_latest_release_download() {
-    if [ -z "$latest" ]; then
-    fail_download
-    fi
+  if [ -z "$latest" ]; then
+  fail_download
+  fi
 }
 
 fail_download() {
-    echo
-    echo "The zipped file was not able to be downladed. This might be because the rate limit of GitHub's API was reached. Please wait a few moments and launch the command again."
-    echo
-    exit 1
+  echo
+  echo "The zipped file was not able to be downladed. This might be because the rate limit of GitHub's API was reached. Please wait a few moments and launch the command again."
+  echo
+  exit 1
 }
 
 # Variables
@@ -98,7 +98,10 @@ fi
 latest=$(get_latest_release medialab/minet)
 
 # Verify that the GH API returned the latest released version
-verify_latest_release_download
+#verify_latest_release_download
+if [ -z "$latest" ]; then
+  fail_download
+fi
 
 # Generic install script
 cleanup

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,12 +56,6 @@ fail_install() {
   exit 1
 }
 
-verify_latest_release_download() {
-  if [ -z "$latest" ]; then
-  fail_download
-  fi
-}
-
 fail_download() {
   echo
   echo "The zipped file was not able to be downladed. This might be because the rate limit of GitHub's API was reached. Please wait a few moments and launch the command again."
@@ -97,8 +91,7 @@ fi
 # Finding latest released version
 latest=$(get_latest_release medialab/minet)
 
-# Verify that the GH API returned the latest released version
-#verify_latest_release_download
+# Verify that the GitHub API returned the latest released version
 if [ -z "$latest" ]; then
   fail_download
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,6 +56,19 @@ fail_install() {
   exit 1
 }
 
+verify_latest_release_download() {
+    if [ -z "$latest" ]; then
+    fail_download
+    fi
+}
+
+fail_download() {
+    echo
+    echo "The zipped file was not able to be downladed. This might be because the rate limit of GitHub's API was reached. Please wait a few moments and launch the command again."
+    echo
+    exit 1
+}
+
 # Variables
 os="unknown"
 
@@ -83,6 +96,9 @@ fi
 
 # Finding latest released version
 latest=$(get_latest_release medialab/minet)
+
+# Verify that the GH API returned the latest released version
+verify_latest_release_download
 
 # Generic install script
 cleanup


### PR DESCRIPTION
The fix I propose sends an error message if the function `get_latest_release()` did not return return anything from GitHub's API, i.e. if the variable `$latest` is empty.