### PR TITLE
fix for CT post_by_id when post not found

### DIFF
--- a/minet/cli/crowdtangle/posts_by_id.py
+++ b/minet/cli/crowdtangle/posts_by_id.py
@@ -51,7 +51,8 @@ def crowdtangle_posts_by_id_action(cli_args):
                 continue
 
             post = client.post(post_id)
-            enricher.writerow(row, post.as_csv_row())
+            if post:
+                enricher.writerow(row, post.as_csv_row())
 
     except CrowdTangleInvalidTokenError:
         loading_bar.die(

--- a/minet/cli/crowdtangle/posts_by_id.py
+++ b/minet/cli/crowdtangle/posts_by_id.py
@@ -12,7 +12,7 @@ import minet.facebook as facebook
 from minet.cli.utils import LoadingBar
 from minet.crowdtangle.constants import CROWDTANGLE_POST_CSV_HEADERS
 from minet.crowdtangle.client import CrowdTangleAPIClient
-from minet.crowdtangle.exceptions import CrowdTangleInvalidTokenError
+from minet.crowdtangle.exceptions import CrowdTangleInvalidTokenError, CrowdTanglePostNotFound
 
 
 def crowdtangle_posts_by_id_action(cli_args):
@@ -50,9 +50,12 @@ def crowdtangle_posts_by_id_action(cli_args):
                 enricher.writerow(row)
                 continue
 
-            post = client.post(post_id)
-            if post:
+            try:
+                post = client.post(post_id)
                 enricher.writerow(row, post.as_csv_row())
+            except CrowdTanglePostNotFound as error:
+                enricher.writerow(row)
+                loading_bar.print(error, repr(error))
 
     except CrowdTangleInvalidTokenError:
         loading_bar.die(

--- a/minet/crowdtangle/client.py
+++ b/minet/crowdtangle/client.py
@@ -91,11 +91,9 @@ class CrowdTangleAPIClient(object):
             raise CrowdTangleInvalidJSONError
 
         try:
-            data["result"]
-        except:
-            print(CrowdTanglePostNotFound(None, data, url).__str__())
-
-        return data.get("result")
+            return data["result"]
+        except KeyError:
+            raise CrowdTanglePostNotFound(None, data, url)
 
     @rate_limited_method("rate_limiter_state")
     def request(self, url):

--- a/minet/crowdtangle/client.py
+++ b/minet/crowdtangle/client.py
@@ -20,6 +20,7 @@ from minet.crowdtangle.exceptions import (
     CrowdTangleRateLimitExceeded,
     CrowdTangleInvalidRequestError,
     CrowdTangleServerError,
+    CrowdTanglePostNotFound
 )
 from minet.crowdtangle.leaderboard import crowdtangle_leaderboard
 from minet.crowdtangle.lists import crowdtangle_lists
@@ -85,11 +86,16 @@ class CrowdTangleAPIClient(object):
             )
 
         try:
-            data = json.loads(response.data)["result"]
-        except (json.decoder.JSONDecodeError, TypeError, KeyError):
+            data = json.loads(response.data)
+        except (json.decoder.JSONDecodeError, TypeError):
             raise CrowdTangleInvalidJSONError
 
-        return data
+        try:
+            data["result"]
+        except:
+            print(CrowdTanglePostNotFound(None, data, url).__str__())
+
+        return data.get("result")
 
     @rate_limited_method("rate_limiter_state")
     def request(self, url):

--- a/minet/crowdtangle/exceptions.py
+++ b/minet/crowdtangle/exceptions.py
@@ -58,3 +58,22 @@ class CrowdTangleInvalidJSONError(CrowdTangleError):
 
 class CrowdTangleRateLimitExceeded(CrowdTangleError):
     pass
+
+class CrowdTanglePostNotFound(CrowdTangleError):
+    def __init__(self, message=None, data=None, url=None):
+        super().__init__(message)
+        self.data = data
+        self.url = url
+        self.message = f"\n\n\
+            CrowdTangle does not have data about the post at URL: {self.url}\n\
+            The CrowdTangle API's response is: \n\
+            {self.data}\n\
+            This URL has been skipped and the inaccessible post will not be output.\n\
+            "
+
+    def __str__(self):
+            
+        if self.data:
+            return super().__str__() + self.message
+        
+        return super().__str__()

--- a/minet/crowdtangle/exceptions.py
+++ b/minet/crowdtangle/exceptions.py
@@ -71,7 +71,7 @@ class CrowdTanglePostNotFound(CrowdTangleError):
             This URL has been skipped and the inaccessible post will not be output.\n\
             "
 
-    def __str__(self):
+    def __repr__(self):
             
         if self.data:
             return super().__str__() + self.message


### PR DESCRIPTION
Fix for issue #467

Creates an Exception that prints an error message but does not exit the program, so that one bad post doesn't interrupt a loop through multiple posts searched by their ID.