### PR TITLE
add timestamp to fetch result and CLI output

### DIFF
--- a/minet/cli/fetch.py
+++ b/minet/cli/fetch.py
@@ -7,6 +7,7 @@
 # optimize both running time & memory.
 #
 import casanova
+from datetime import datetime
 from io import StringIO
 from collections import Counter
 from ural import is_shortened_url
@@ -24,7 +25,7 @@ from minet.cli.utils import LoadingBar, die
 FETCH_ADDITIONAL_HEADERS = [
     "resolved",
     "status",
-    "timestamp",
+    "datetime_utc",
     "error",
     "filename",
     "mimetype",
@@ -269,7 +270,7 @@ def fetch_action(cli_args, resolve=False, defer=None):
         row,
         resolved=None,
         status=None,
-        timestamp=None,
+        datetime_utc=None,
         error=None,
         filename=None,
         encoding=None,
@@ -280,7 +281,7 @@ def fetch_action(cli_args, resolve=False, defer=None):
         addendum = [
             resolved or "",
             status or "",
-            timestamp or "",
+            datetime_utc or "",
             error or "",
             filename or "",
             mimetype or "",
@@ -361,7 +362,7 @@ def fetch_action(cli_args, resolve=False, defer=None):
                     row,
                     resolved=resolved_url,
                     status=result.response.status,
-                    timestamp=meta.get("timestamp").strftime("%Y-%m-%dT%H:%M:%S"),
+                    datetime_utc=datetime.isoformat(meta.get("datetime_utc")),
                     filename=meta.get("filename"),
                     encoding=meta.get("encoding"),
                     mimetype=meta.get("mimetype"),

--- a/minet/cli/fetch.py
+++ b/minet/cli/fetch.py
@@ -24,6 +24,7 @@ from minet.cli.utils import LoadingBar, die
 FETCH_ADDITIONAL_HEADERS = [
     "resolved",
     "status",
+    "timestamp",
     "error",
     "filename",
     "mimetype",
@@ -268,6 +269,7 @@ def fetch_action(cli_args, resolve=False, defer=None):
         row,
         resolved=None,
         status=None,
+        timestamp=None,
         error=None,
         filename=None,
         encoding=None,
@@ -278,6 +280,7 @@ def fetch_action(cli_args, resolve=False, defer=None):
         addendum = [
             resolved or "",
             status or "",
+            timestamp or "",
             error or "",
             filename or "",
             mimetype or "",
@@ -358,6 +361,7 @@ def fetch_action(cli_args, resolve=False, defer=None):
                     row,
                     resolved=resolved_url,
                     status=result.response.status,
+                    timestamp=meta.get("timestamp").strftime("%Y-%m-%dT%H:%M:%S"),
                     filename=meta.get("filename"),
                     encoding=meta.get("encoding"),
                     mimetype=meta.get("mimetype"),

--- a/minet/fetch.py
+++ b/minet/fetch.py
@@ -40,10 +40,11 @@ class FetchResult(object):
         if not self.url:
             return "<{name} empty!>".format(name=name)
 
-        return "<{name}{errored} url={url!r} status={status!r} ext={ext!r} encoding={encoding!r}>".format(
+        return "<{name}{errored} url={url!r} status={status!r} timestamp={timestamp!r} ext={ext!r} encoding={encoding!r}>".format(
             name=name,
             url=self.url,
             status=self.response.status if self.response else None,
+            timestamp=self.meta.get("timestamp").strftime("%Y-%m-%dT%H:%M:%S"),
             ext=self.meta.get("ext"),
             encoding=self.meta.get("encoding"),
             errored=" errored!" if self.error else "",

--- a/minet/fetch.py
+++ b/minet/fetch.py
@@ -6,6 +6,7 @@
 # web in a multithreaded fashion.
 #
 from collections import namedtuple
+from datetime import datetime
 from quenouille import ThreadPoolExecutor
 from ural import get_domain_name, ensure_protocol
 
@@ -40,11 +41,11 @@ class FetchResult(object):
         if not self.url:
             return "<{name} empty!>".format(name=name)
 
-        return "<{name}{errored} url={url!r} status={status!r} timestamp={timestamp!r} ext={ext!r} encoding={encoding!r}>".format(
+        return "<{name}{errored} url={url!r} status={status!r} datetime_utc={datetime_utc!r} ext={ext!r} encoding={encoding!r}>".format(
             name=name,
             url=self.url,
             status=self.response.status if self.response else None,
-            timestamp=self.meta.get("timestamp").strftime("%Y-%m-%dT%H:%M:%S"),
+            datetime_utc=datetime.isoformat(self.meta.get("datetime_utc")),
             ext=self.meta.get("ext"),
             encoding=self.meta.get("encoding"),
             errored=" errored!" if self.error else "",

--- a/minet/web.py
+++ b/minet/web.py
@@ -654,10 +654,10 @@ def resolve(
 
 
 def extract_response_meta(response, guess_encoding=True, guess_extension=True):
-    meta = {"ext": None, "mimetype": None, "encoding": None, "is_text": None, "timestamp": None}
+    meta = {"ext": None, "mimetype": None, "encoding": None, "is_text": None, "datetime_utc": None}
 
-    # Setting timestamp
-    meta["timestamp"] = datetime.now()
+    # Marking time at which the fetch result object was created
+    meta["datetime_utc"] = datetime.utcnow()
 
     # Guessing extension
     if guess_extension:

--- a/minet/web.py
+++ b/minet/web.py
@@ -7,6 +7,7 @@
 import re
 import cgi
 import certifi
+from datetime import datetime
 import browser_cookie3
 import urllib3
 import urllib.error
@@ -653,7 +654,10 @@ def resolve(
 
 
 def extract_response_meta(response, guess_encoding=True, guess_extension=True):
-    meta = {"ext": None, "mimetype": None, "encoding": None, "is_text": None}
+    meta = {"ext": None, "mimetype": None, "encoding": None, "is_text": None, "timestamp": None}
+
+    # Setting timestamp
+    meta["timestamp"] = datetime.now()
 
     # Guessing extension
     if guess_extension:


### PR DESCRIPTION
To the fetch result's attribute "meta", which is a dictionary, I added a datetime object that holds the time (`datetime.datetime.now()`) in which the fetch result was initiated. In the fetch result's representation (`__rep__`), the timestamp is transformed into a string.

Example:
```
>>> from minet import multithreaded_fetch
>>> urls = ["iscaliforniaonfire.com"]
>>> results = [result for result in multithreaded_fetch(urls)]
>>> print(results)
[<FetchResult url='http://iscaliforniaonfire.com' status=200 timestamp='2022-12-06T17:44:23' ext='.html' encoding='ascii'>]
>>> print(results[0].meta["timestamp"])
2022-12-06 17:44:23.372471
>>> print(type(results[0].meta["timestamp"]))
<class 'datetime.datetime'>
```

To the file that CLI fetch writes, I added the column "timestamp" and passed a string of the fetch result's timestamp attribute to the contents written in the file.

Example (xsv flatten):
```
url        http://iscaliforniaonfire.com/
index      0
resolved   
status     200
timestamp  2022-12-06T17:34:48
error      
filename   02dc25b198a69b66e9a8fccef13b460a.html
mimetype   text/html
encoding   ascii
```