### PR TITLE
removing the flag --keep-irrelevant for the focus crawler

### DIFF
--- a/minet/cli/crawl/__init__.py
+++ b/minet/cli/crawl/__init__.py
@@ -218,11 +218,6 @@ FOCUS_CRAWL_COMMAND = crawl_command(
             "flag": "--only-html",
             "help": "Add URLs to the crawler queue only if they seem to lead to a HTML content.",
             "action": "store_true",
-        },
-        {
-            "flag": "--keep-irrelevant",
-            "help": "Add to exported data the results judged irrelevant by the algorithm.",
-            "action": "store_true",
-        },
+        }
     ],
 )


### PR DESCRIPTION
Pull request to remove the flag `--keep-irrelevant` from the focus-crawl command considering it is not used any more.