### PR TITLE
Flags to turn regexs into negative filters (focus crawler)

### DIFF
--- a/minet/cli/crawl/__init__.py
+++ b/minet/cli/crawl/__init__.py
@@ -245,12 +245,12 @@ FOCUS_CRAWL_COMMAND = crawl_command(
             "default": None,
         },
         {
-            "flags": ["-nC", "--negative-content-filter"],
+            "flag": "--invert-content-match",
             "help": "Flag to turn the content filter into an exclusion rule.",
             "action": "store_true",
         },
         {
-            "flags": ["-nU", "--negative-url-filter"],
+            "flag": "--invert-url-match",
             "help": "Flag to turn the url filter into an exclusion rule.",
             "action": "store_true",
         },

--- a/minet/cli/crawl/__init__.py
+++ b/minet/cli/crawl/__init__.py
@@ -245,6 +245,16 @@ FOCUS_CRAWL_COMMAND = crawl_command(
             "default": None,
         },
         {
+            "flags": ["-nC", "--negative-content-filter"],
+            "help": "Flag to turn the content filter into an exclusion rule",
+            "action": "store_true",
+        },
+        {
+            "flags": ["-nU", "--negative-url-filter"],
+            "help": "Flag to turn the url filter into an exclusion rule",
+            "action": "store_true",
+        },
+        {
             "flag": "--extract",
             "help": "Perform regex match on extracted text content instead of html content using the Trafilatura library.",
             "action": "store_true",

--- a/minet/cli/crawl/__init__.py
+++ b/minet/cli/crawl/__init__.py
@@ -246,12 +246,12 @@ FOCUS_CRAWL_COMMAND = crawl_command(
         },
         {
             "flags": ["-nC", "--negative-content-filter"],
-            "help": "Flag to turn the content filter into an exclusion rule",
+            "help": "Flag to turn the content filter into an exclusion rule.",
             "action": "store_true",
         },
         {
             "flags": ["-nU", "--negative-url-filter"],
-            "help": "Flag to turn the url filter into an exclusion rule",
+            "help": "Flag to turn the url filter into an exclusion rule.",
             "action": "store_true",
         },
         {

--- a/minet/cli/crawl/focus_crawl.py
+++ b/minet/cli/crawl/focus_crawl.py
@@ -12,9 +12,9 @@ def action(cli_args):
 
     spider = FocusSpider(
         regex_content=cli_args.content_filter,
-        negative_regex_content=cli_args.negative_content_filter,
+        invert_content_match=cli_args.invert_content_match,
         regex_url=cli_args.url_filter,
-        negative_regex_url=cli_args.negative_url_filter,
+        invert_url_match=cli_args.invert_url_match,
         irrelevant_continue=cli_args.irrelevant_continue,
         only_target_html_page=cli_args.only_html,
         extract=cli_args.extract,

--- a/minet/cli/crawl/focus_crawl.py
+++ b/minet/cli/crawl/focus_crawl.py
@@ -12,7 +12,9 @@ def action(cli_args):
 
     spider = FocusSpider(
         regex_content=cli_args.content_filter,
+        negative_regex_content=cli_args.negative_content_filter,
         regex_url=cli_args.url_filter,
+        negative_regex_url=cli_args.negative_url_filter,
         irrelevant_continue=cli_args.irrelevant_continue,
         only_target_html_page=cli_args.only_html,
         extract=cli_args.extract,


### PR DESCRIPTION
Improvement to the focus crawler that adds the possibility to reverse the effect of the content and url filters.

The new flags are : 
* `-nU / --negative-url-filter` : Flag to turn the url filter into an exclusion rule.
* `-nC / --negative-content-filter` : Flag to turn the content filter into an exclusion rule.